### PR TITLE
Framcc feat/market maker key

### DIFF
--- a/apps/exchange/example-config.json
+++ b/apps/exchange/example-config.json
@@ -15,5 +15,6 @@
     }
   ],
   "database": "user=postgres host=winhost port=5432 password=1324 dbname=simulate-exchange",
-  "exchangeId": "d4072440-06ff-470a-a56e-e16f2162b338"
+  "exchangeId": "d4072440-06ff-470a-a56e-e16f2162b338",
+  "marketMakerKey": "asdjklfiasdklfijklds"
 }

--- a/apps/exchange/libs/config/config.cc
+++ b/apps/exchange/libs/config/config.cc
@@ -6,8 +6,13 @@ namespace Sim::Config
         uint32_t port,
         std::vector<Instrument> instruments,
         std::string dbString,
-        std::string exchangeId)
-        : mPort{ port }, mInstruments{ instruments }, mDbString{ dbString }, mExchangeId{ exchangeId }
+        std::string exchangeId,
+        std::string marketMakerKey)
+        : mPort{ port },
+          mInstruments{ instruments },
+          mDbString{ dbString },
+          mExchangeId{ exchangeId },
+          mMarketMakerKey{ marketMakerKey }
     {}
 
     const std::vector<Instrument>& ExchangeConfig::getInstruments() const { return mInstruments; }
@@ -17,5 +22,7 @@ namespace Sim::Config
     const std::string& ExchangeConfig::getDbString() const { return mDbString; }
 
     const std::string& ExchangeConfig::getExchangeId() const { return mExchangeId; }
+
+    const std::string& ExchangeConfig::getMarketMakerKey() const { return mMarketMakerKey; }
 
 } // namespace Sim::Config

--- a/apps/exchange/libs/config/config.h
+++ b/apps/exchange/libs/config/config.h
@@ -16,6 +16,7 @@ namespace Sim::Config
         virtual const std::vector<Instrument>& getInstruments() const = 0;
         virtual const std::string& getDbString() const = 0;
         virtual const std::string& getExchangeId() const = 0;
+        virtual const std::string& getMarketMakerKey() const = 0;
     };
 
     class ExchangeConfig : public IConfig
@@ -25,18 +26,21 @@ namespace Sim::Config
             uint32_t port,
             std::vector<Instrument> instruments,
             std::string dbString,
-            std::string exchangeId);
+            std::string exchangeId,
+            std::string marketMakerKey);
         virtual ~ExchangeConfig() override = default;
 
         uint32_t getPort() const override;
         const std::vector<Instrument>& getInstruments() const override;
         const std::string& getDbString() const override;
         const std::string& getExchangeId() const override;
+        const std::string& getMarketMakerKey() const override;
 
        private:
         uint32_t mPort;
         std::vector<Instrument> mInstruments;
         std::string mDbString;
         std::string mExchangeId;
+        std::string mMarketMakerKey;
     };
 } // namespace Sim::Config

--- a/apps/exchange/libs/config/config_reader.cc
+++ b/apps/exchange/libs/config/config_reader.cc
@@ -35,8 +35,9 @@ namespace Sim::Config
 
         auto dbString = document["database"].GetString();
         auto exchangeId = document["exchangeId"].GetString();
+        auto marketMakerKey = document["marketMakerKey"].GetString();
 
-        return ExchangeConfig(port, instrumentVector, dbString, exchangeId);
+        return ExchangeConfig(port, instrumentVector, dbString, exchangeId, marketMakerKey);
     }
 
     bool ConfigReader::validate(int argc, char* argv[]) const

--- a/apps/exchange/libs/engine/participant.h
+++ b/apps/exchange/libs/engine/participant.h
@@ -28,6 +28,8 @@ namespace Sim
         void setId(uint32_t id);
         uint32_t getId() const;
 
+        void upgrade();
+
         bool requestOrderInsert(Protocol::InsertOrderRequest& order);
         bool requestOrderCancel(Protocol::CancelOrderRequest& order);
 
@@ -58,6 +60,7 @@ namespace Sim
         uint32_t mIdentifier;
         std::string mUserId;
         bool mLoggedIn{ false };
+        bool mMarketMaker{ false };
 
         std::unique_ptr<OrderFactory> mOrderFactory;
         uint64_t expectedOrderId = 0;

--- a/apps/exchange/libs/net/exchange_runtime.cc
+++ b/apps/exchange/libs/net/exchange_runtime.cc
@@ -84,17 +84,26 @@ namespace Sim::Net
                 }
 
                 const auto& key = loginRequest.key();
-                const auto& loginKey = checkKey(key);
 
-                if (!loginKey.has_value())
+                if (key == mConfig.getMarketMakerKey())
                 {
-                    sender->raiseError("Invalid login key.");
-                    return;
+                    sender->upgrade();
+                }
+                else
+                {
+                    const auto& loginUserId = checkKey(key);
+                    if (!loginUserId.has_value())
+                    {
+                        sender->raiseError("Invalid login key.");
+                        return;
+                    }
+
+                    // the userId is not used by market maker participants
+                    sender->login(*loginUserId);
                 }
 
                 sendMessage(
                     *connection, Protocol::LOGIN_RESPONSE, mExchange.getExchangeInstruments().SerializeAsString());
-                sender->login(*loginKey);
 
                 break;
             }

--- a/apps/exchange/tests/config_reader_test.cc
+++ b/apps/exchange/tests/config_reader_test.cc
@@ -35,7 +35,8 @@ namespace Sim::Testing
                 }
             ],
             "database": "user=postgres host=winhost port=5432 password=1324 dbname=simulate.exchange",
-            "exchangeId": "123abc"
+            "exchangeId": "123abc",
+            "marketMakerKey": "my-secret-key"
         }
         )";
 

--- a/apps/exchange/tests/config_test.cc
+++ b/apps/exchange/tests/config_test.cc
@@ -9,7 +9,7 @@ namespace Sim::Testing
     {
        protected:
         ConfigTestFixture()
-            : mConfig(Config::ExchangeConfig(0, std::vector<Instrument>(), std::string(), std::string()))
+            : mConfig(Config::ExchangeConfig(0, std::vector<Instrument>(), std::string(), std::string(), std::string()))
         {}
 
         struct ConfigOptions
@@ -18,12 +18,13 @@ namespace Sim::Testing
             std::vector<Instrument> mInstruments;
             std::string mDbString;
             std::string mExchangeId;
+            std::string mMarketMakerKey;
         };
 
         void createConfig(ConfigOptions options)
         {
-            mConfig =
-                Config::ExchangeConfig(options.mPort, options.mInstruments, options.mDbString, options.mExchangeId);
+            mConfig = Config::ExchangeConfig(
+                options.mPort, options.mInstruments, options.mDbString, options.mExchangeId, options.mMarketMakerKey);
         }
 
         Config::ExchangeConfig mConfig;

--- a/apps/exchange/tests/test_common.h
+++ b/apps/exchange/tests/test_common.h
@@ -59,6 +59,7 @@ namespace Sim::Testing
         MOCK_METHOD(const std::vector<Instrument>&, getInstruments, (), (const));
         MOCK_METHOD(const std::string&, getDbString, (), (const));
         MOCK_METHOD(const std::string&, getExchangeId, (), (const));
+        MOCK_METHOD(const std::string&, getMarketMakerKey, (), (const));
     };
 
     struct MockExchange : public IExchange


### PR DESCRIPTION
https://simulate-exchange.notion.site/Update-exchange-for-data-gen-participant-3e64c6571cf74c0289188788b5618de3

`marketMakerKey` in json config
Participants with market maker key will not write their sides of the trade to the database.