### PR TITLE
Framcc feature/limits

### DIFF
--- a/apps/exchange/libs/engine/participant.cc
+++ b/apps/exchange/libs/engine/participant.cc
@@ -55,6 +55,21 @@ namespace Sim
             return false;
         }
 
+        if (order.volume() == 0)
+        {
+            raiseError(
+                "Invalid order with price:" + std::to_string(order.price()) +
+                "and volume:" + std::to_string(order.volume()));
+            return false;
+        }
+
+        auto tickSize = mConfig.getInstruments().at(order.instrumentid()).mTickSizeCents;
+        if (order.price() % tickSize != 0)
+        {
+            raiseError("Invalid Order! Price: [" + std::to_string(order.price()) + "] is not a valid tick size.");
+            return false;
+        }
+
         auto newOrder = mOrderFactory->createOrder(order, [this](Order* order) {
             if (mOrders.size())
             {

--- a/apps/exchange/libs/engine/participant.cc
+++ b/apps/exchange/libs/engine/participant.cc
@@ -1,6 +1,7 @@
 #include "conversions.h"
 #include "participant.h"
 
+#include <cmath>
 #include <functional>
 
 namespace Sim
@@ -156,6 +157,12 @@ namespace Sim
         {
             mPositions[order.mInstrument] -= volumeFilled;
             mCash += volumeFilled * price;
+        }
+
+        if (!mMarketMaker &&
+            std::abs(mPositions[order.mInstrument]) > mConfig.getInstruments().at(order.mInstrument).mPositionLimit)
+        {
+            raiseError("Position limit exceeded");
         }
 
         Protocol::OrderFillMessage message;

--- a/apps/exchange/main.cc
+++ b/apps/exchange/main.cc
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
     timer.start([&]() {
         // exchangeRuntime.diagnose();
         exchangeRuntime.sendPriceFeed();
-        // exchangeRuntime.getExchange().printBooks();
+        exchangeRuntime.getExchange().printBooks();
     });
 
     for (const auto& instrument : instruments)

--- a/apps/exchange/tests/participant_test.cc
+++ b/apps/exchange/tests/participant_test.cc
@@ -24,6 +24,12 @@ namespace Sim::Testing
                 .mTickSizeCents = 1,
                 .mId = "def",
             });
+            mInstruments.emplace_back(Instrument{
+                .mName = "FFF",
+                .mPositionLimit = 100,
+                .mTickSizeCents = 2,
+                .mId = "ghi",
+            });
 
             ON_CALL(*mConfig, getInstruments()).WillByDefault(ReturnRef(mInstruments));
         }
@@ -35,6 +41,20 @@ namespace Sim::Testing
 
             mParticipant = std::make_unique<MockParticipant>(
                 std::move(orderFactory), Protocol::LoginResponse(), *mConnection, *mConfig);
+        }
+
+        Protocol::InsertOrderRequest makeRequest()
+        {
+            Protocol::InsertOrderRequest request;
+
+            request.set_instrumentid(0);
+            request.set_clientid(0);
+            request.set_price(1);
+            request.set_volume(1);
+            request.set_lifespan(Protocol::InsertOrderRequest::GFD);
+            request.set_side(Protocol::InsertOrderRequest::BUY);
+
+            return request;
         }
 
         std::vector<Instrument> mInstruments;
@@ -60,7 +80,7 @@ namespace Sim::Testing
             return true;
         });
 
-        Protocol::InsertOrderRequest request;
+        Protocol::InsertOrderRequest request = makeRequest();
 
         mParticipant->requestOrderInsert(request);
 
@@ -78,7 +98,7 @@ namespace Sim::Testing
     {
         setupParticipant([](MockOrderFactory& factory) { EXPECT_CALL(factory, createOrder(_, _)).Times(0); });
 
-        Protocol::InsertOrderRequest request;
+        Protocol::InsertOrderRequest request = makeRequest();
         request.set_clientid(1);
 
         ASSERT_FALSE(mParticipant->requestOrderInsert(request));
@@ -99,13 +119,13 @@ namespace Sim::Testing
             return true;
         });
 
-        Protocol::InsertOrderRequest request1;
+        Protocol::InsertOrderRequest request1 = makeRequest();
         request1.set_clientid(0);
 
-        Protocol::InsertOrderRequest request2;
+        Protocol::InsertOrderRequest request2 = makeRequest();
         request2.set_clientid(1);
 
-        Protocol::InsertOrderRequest request3;
+        Protocol::InsertOrderRequest request3 = makeRequest();
         request3.set_clientid(1);
 
         ASSERT_TRUE(mParticipant->requestOrderInsert(request1));
@@ -123,7 +143,7 @@ namespace Sim::Testing
                 .WillOnce(Return(ByMove(std::make_unique<Order>(1, 1, Lifespan::FAK, Side::SELL, 1, 1))));
         });
 
-        Protocol::InsertOrderRequest request;
+        Protocol::InsertOrderRequest request = makeRequest();
         request.set_clientid(0);
 
         ASSERT_THROW({ mParticipant->requestOrderInsert(request); }, std::runtime_error);
@@ -148,7 +168,7 @@ namespace Sim::Testing
             return true;
         });
 
-        Protocol::InsertOrderRequest request;
+        Protocol::InsertOrderRequest request = makeRequest();
         mParticipant->requestOrderInsert(request);
 
         orderPtr->mOrderListener->onFill(*orderPtr, 10, 10);
@@ -176,7 +196,7 @@ namespace Sim::Testing
             return true;
         });
 
-        Protocol::InsertOrderRequest request;
+        Protocol::InsertOrderRequest request = makeRequest();
         mParticipant->requestOrderInsert(request);
 
         Protocol::CancelOrderRequest cancelRequest;
@@ -218,6 +238,36 @@ namespace Sim::Testing
 
         ASSERT_FALSE(isCancelCalled);
         ASSERT_EQ(orderToCancel, nullptr);
+    }
+
+    TEST_F(ParticipantTestFixture, VolumeOfZeroRejected)
+    {
+        setupParticipant([](MockOrderFactory& factory) {});
+
+        int callCount = 0;
+        mParticipant->setErrorHandler([&callCount](const std::string& messsage) { callCount++; });
+
+        Protocol::InsertOrderRequest request = makeRequest();
+        request.set_clientid(0);
+        request.set_volume(0);
+        ASSERT_FALSE(mParticipant->requestOrderInsert(request));
+
+        ASSERT_EQ(callCount, 1);
+    }
+
+    TEST_F(ParticipantTestFixture, OffTickPriceRejected)
+    {
+        setupParticipant([](MockOrderFactory& factory) {});
+
+        int callCount = 0;
+        mParticipant->setErrorHandler([&callCount](const std::string& messsage) { callCount++; });
+
+        Protocol::InsertOrderRequest request = makeRequest();
+        request.set_price(1);
+        request.set_instrumentid(2);
+        ASSERT_FALSE(mParticipant->requestOrderInsert(request));
+
+        ASSERT_EQ(callCount, 1);
     }
 
 } // namespace Sim::Testing

--- a/apps/exchange/tests/participant_test.cc
+++ b/apps/exchange/tests/participant_test.cc
@@ -270,4 +270,22 @@ namespace Sim::Testing
         ASSERT_EQ(callCount, 1);
     }
 
+    TEST_F(ParticipantTestFixture, ExceedingPositionLimitKicksFromExchange)
+    {
+        setupParticipant([](MockOrderFactory& factory) {});
+
+        int callCount = 0;
+        mParticipant->setErrorHandler([&callCount](const std::string& messsage) { callCount++; });
+
+        Order order{ 0, 1, Lifespan::FAK, Side::SELL, 1, 101 };
+
+        // ok
+        mParticipant->handleOrderFill(order, 100, 1);
+
+        // bad
+        mParticipant->handleOrderFill(order, 1, 1);
+
+        EXPECT_EQ(callCount, 1);
+    }
+
 } // namespace Sim::Testing

--- a/apps/exchange/tests/participant_test.cc
+++ b/apps/exchange/tests/participant_test.cc
@@ -11,7 +11,22 @@ namespace Sim::Testing
        protected:
         ParticipantTestFixture()
             : mConnection{ std::make_unique<MockConnection>() }, mConfig{ std::make_unique<MockConfig>() }
-        {}
+        {
+            mInstruments.emplace_back(Instrument{
+                .mName = "AAPL",
+                .mPositionLimit = 100,
+                .mTickSizeCents = 1,
+                .mId = "abc",
+            });
+            mInstruments.emplace_back(Instrument{
+                .mName = "NVDA",
+                .mPositionLimit = 100,
+                .mTickSizeCents = 1,
+                .mId = "def",
+            });
+
+            ON_CALL(*mConfig, getInstruments()).WillByDefault(ReturnRef(mInstruments));
+        }
 
         void setupParticipant(std::function<void(MockOrderFactory&)> applicator)
         {
@@ -22,6 +37,7 @@ namespace Sim::Testing
                 std::move(orderFactory), Protocol::LoginResponse(), *mConnection, *mConfig);
         }
 
+        std::vector<Instrument> mInstruments;
         std::unique_ptr<Db::IConnection> mConnection;
         std::unique_ptr<MockConfig> mConfig;
         std::unique_ptr<MockParticipant> mParticipant;


### PR DESCRIPTION
https://simulate-exchange.notion.site/Exchange-Limits-44453d4cbeff4d1d804accc328696107

- Reject orders that are not on the tick size.
- Kick off exchange if the position limit is breached.